### PR TITLE
Add htmlspecialchars to escape special caracters

### DIFF
--- a/View/Vote/admin_configuration.ctp
+++ b/View/Vote/admin_configuration.ctp
@@ -20,7 +20,7 @@
                         <div class="form-group">
                             <label><?= $Lang->get('VOTE__ADMIN_VOTE_CONFIGURATION_GLOBAL_COMMAND') ?></label>
                             <input name="global_command" class="form-control" type="text"
-                                   value="<?= $configuration['global_command'] ?>"><br>
+                                   value="<?= htmlspecialchars($configuration['global_command']) ?>"><br>
                             <small>
                                 <b>{PLAYER}</b> = Pseudo du voteur <br>
                                 <b>{REWARD_NAME}</b> = Nom de la récompense (Quand il n'y a qu'une récompense) <br>
@@ -31,7 +31,7 @@
                         <div class="form-group">
                             <label><?= $Lang->get('VOTE__ADMIN_VOTE_CONFIGURATION_GLOBAL_COMMAND_PLURAL') ?></label>
                             <input name="global_command_plural" class="form-control" type="text"
-                                   value="<?= $configuration['global_command_plural'] ?>"><br>
+                                   value="<?= htmlspecialchars($configuration['global_command_plural']) ?>"><br>
                             <small>
                                 <b>{PLAYER}</b> = Pseudo du voteur <br>
                                 <b>{REWARD_NUMBER}</b> = Nombre de récompenses en attentes <br>


### PR DESCRIPTION
If we enter a command with a double-quote ( " ), this character isn't escaped so the dom could be edited

Si on entre une commande avec un double-guillemet ( " ), ce caractère n'est pas échappé et donc le dom peut être modifié